### PR TITLE
fix: Remove duplicate OpenAI API calls that caused rate limit exhaustion

### DIFF
--- a/backend/src/adapters/openaiAdapter.ts
+++ b/backend/src/adapters/openaiAdapter.ts
@@ -207,6 +207,9 @@ Answer based on this data.`;
    * Parse AI response and extract structured data
    */
   private parseAIResponse(response: string, files: DriveFileData[]): AIResponse {
+    // Generate statistics from files
+    const statistics = this.generateFileStatistics(files);
+    
     try {
       // Try to parse as JSON first
       const parsed = JSON.parse(response);
@@ -214,7 +217,8 @@ Answer based on this data.`;
         answer: parsed.answer || response,
         confidence: parsed.confidence || 0.8,
         sources: parsed.sources || [],
-        reasoning: parsed.reasoning
+        reasoning: parsed.reasoning,
+        statistics
       };
     } catch {
       // If not JSON, treat as plain text answer
@@ -222,9 +226,50 @@ Answer based on this data.`;
         answer: response,
         confidence: 0.7,
         sources: files.slice(0, 3).map(f => f.name), // Use first few files as sources
-        reasoning: 'Response parsed as plain text'
+        reasoning: 'Response parsed as plain text',
+        statistics
       };
     }
+  }
+
+  private generateFileStatistics(files: DriveFileData[]): FileStatistics {
+    const totalFiles = files.length;
+    const totalSize = files.reduce((sum, file) => sum + file.size, 0);
+    const averageSize = totalFiles > 0 ? Math.round(totalSize / totalFiles) : 0;
+    
+    // Count file types
+    const fileTypes: Record<string, number> = {};
+    files.forEach(file => {
+      const type = file.mimeType.split('/')[0]; // Get main type (e.g., 'application' from 'application/pdf')
+      fileTypes[type] = (fileTypes[type] || 0) + 1;
+    });
+    
+    // Count owners
+    const owners: Record<string, number> = {};
+    files.forEach(file => {
+      const owner = file.owner || 'Unknown';
+      owners[owner] = (owners[owner] || 0) + 1;
+    });
+    
+    // Get recent files (last 5)
+    const recentFiles = [...files]
+      .sort((a, b) => new Date(b.modifiedTime).getTime() - new Date(a.modifiedTime).getTime())
+      .slice(0, 5);
+    
+    // Get largest files (top 5)
+    const largestFiles = [...files]
+      .sort((a, b) => b.size - a.size)
+      .slice(0, 5);
+    
+    return {
+      totalFiles,
+      totalSize,
+      averageSize,
+      fileTypes,
+      owners,
+      recentFiles,
+      largestFiles
+    };
   }
 
   /**

--- a/backend/src/interfaces/aiProvider.ts
+++ b/backend/src/interfaces/aiProvider.ts
@@ -33,6 +33,7 @@ export interface AIResponse {
   confidence: number;
   sources: string[];
   reasoning?: string;
+  statistics?: FileStatistics;
 }
 
 export interface FileStatistics {

--- a/backend/src/routes/ai.ts
+++ b/backend/src/routes/ai.ts
@@ -211,9 +211,6 @@ router.post('/rag/query', async (req: Request & { user?: { id: string; email?: s
       owner: file.owner || 'Unknown'
     }));
 
-    // Get file statistics
-    const statistics = await aiService.getFileStatistics(driveFiles);
-
     // Create question context for AI analysis
     const questionContext: QuestionContext = {
       question: trimmedQuestion,
@@ -221,7 +218,7 @@ router.post('/rag/query', async (req: Request & { user?: { id: string; email?: s
       userEmail: req.user.email || 'Unknown'
     };
 
-    // Get AI response with statistics
+    // Get AI response (includes statistics)
     const aiResponse = await aiService.answerQuestion(questionContext);
 
     return res.json({
@@ -231,7 +228,7 @@ router.post('/rag/query', async (req: Request & { user?: { id: string; email?: s
       sources: aiResponse.sources,
       reasoning: aiResponse.reasoning,
       type: 'metadata',
-      statistics: statistics,
+      statistics: aiResponse.statistics,
       totalFiles: files.length,
       filters: filters || {},
       timestamp: new Date().toISOString()


### PR DESCRIPTION
- Remove redundant getFileStatistics() call in AI routes
- Generate statistics locally in OpenAIAdapter instead of separate API call
- Add statistics field to AIResponse interface
- Reduce token usage from 2 API calls per request to 1 API call per request